### PR TITLE
Annotate public API with Android's support annotations

### DIFF
--- a/frenchtoast/build.gradle
+++ b/frenchtoast/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 dependencies {
+  compile 'com.android.support:support-annotations:23.0.0'
 }
 
 def gitSha() {

--- a/frenchtoast/src/main/java/frenchtoast/FrenchToast.java
+++ b/frenchtoast/src/main/java/frenchtoast/FrenchToast.java
@@ -6,6 +6,10 @@ import android.app.Application;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.os.Bundle;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.MainThread;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Toast;
@@ -23,7 +27,7 @@ public final class FrenchToast {
 
   private static QueueHolder queueHolder;
 
-  public static void install(Application application) {
+  @MainThread public static void install(@NonNull Application application) {
     assertMainThread();
     checkNotNull(application, "application");
     if (queueHolder != null) {
@@ -33,7 +37,7 @@ public final class FrenchToast {
     application.registerActivityLifecycleCallbacks(queueHolder);
   }
 
-  public static SmartToaster with(Context context) {
+  @MainThread public static SmartToaster with(@NonNull Context context) {
     assertMainThread();
     checkNotNull(context, "context");
     Activity activity = unwrapActivity(context);
@@ -84,25 +88,25 @@ public final class FrenchToast {
       this.activity = activity;
     }
 
-    @Override public Toaster shortLength() {
+    @Override @MainThread public Toaster shortLength() {
       assertMainThread();
       durationMs = ANDROID_SHORT_DELAY_MS;
       return this;
     }
 
-    @Override public Toaster longLength() {
+    @Override @MainThread public Toaster longLength() {
       assertMainThread();
       durationMs = ANDROID_LONG_DELAY_MS;
       return this;
     }
 
-    @Override public Toaster length(long duration, TimeUnit timeUnit) {
+    @Override @MainThread public Toaster length(long duration, TimeUnit timeUnit) {
       assertMainThread();
       durationMs = timeUnit.toMillis(duration);
       return this;
     }
 
-    @Override public void clear() {
+    @Override @MainThread public void clear() {
       assertMainThread();
       queueHolder.clear(activity);
     }
@@ -113,13 +117,13 @@ public final class FrenchToast {
       return showDipped(toast);
     }
 
-    @Override public Toasted showText(int stringResId) {
+    @Override public Toasted showText(@StringRes int stringResId) {
       @SuppressLint("ShowToast") Toast toast =
           Toast.makeText(activity.getApplicationContext(), stringResId, IGNORED);
       return showDipped(toast);
     }
 
-    @Override public Toasted showLayout(int layoutResId) {
+    @Override public Toasted showLayout(@LayoutRes int layoutResId) {
       Context context = activity.getApplicationContext();
       View view = LayoutInflater.from(context).inflate(layoutResId, null);
       Toast toast = new Toast(context);
@@ -127,7 +131,7 @@ public final class FrenchToast {
       return showDipped(toast);
     }
 
-    @Override public Toasted showDipped(Toast toast) {
+    @Override @MainThread public Toasted showDipped(Toast toast) {
       assertMainThread();
       Mixture mixture = Mixture.dip(toast);
       ToastQueue queue = queueHolder.getOrCreateActivityToastQueue(activity);

--- a/frenchtoast/src/main/java/frenchtoast/LifecycleToastQueue.java
+++ b/frenchtoast/src/main/java/frenchtoast/LifecycleToastQueue.java
@@ -1,5 +1,7 @@
 package frenchtoast;
 
+import android.support.annotation.MainThread;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -47,11 +49,11 @@ public final class LifecycleToastQueue implements ToastQueue {
 
   private boolean paused;
 
-  public LifecycleToastQueue() {
+  @MainThread public LifecycleToastQueue() {
     assertMainThread();
   }
 
-  @Override public void clear() {
+  @Override @MainThread public void clear() {
     assertMainThread();
     if (toastDeque.isEmpty()) {
       return;
@@ -64,7 +66,7 @@ public final class LifecycleToastQueue implements ToastQueue {
     toastDeque.clear();
   }
 
-  @Override public boolean cancel(Mixture canceledMixture) {
+  @Override @MainThread public boolean cancel(Mixture canceledMixture) {
     assertMainThread();
     if (toastDeque.isEmpty()) {
       return false;
@@ -91,7 +93,7 @@ public final class LifecycleToastQueue implements ToastQueue {
     return removed;
   }
 
-  public void pause() {
+  @MainThread public void pause() {
     assertMainThread();
     if (paused) {
       return;
@@ -105,7 +107,7 @@ public final class LifecycleToastQueue implements ToastQueue {
     MAIN_HANDLER.removeCallbacks(hideToast);
   }
 
-  public void resume() {
+  @MainThread public void resume() {
     assertMainThread();
     if (!paused) {
       return;
@@ -114,7 +116,7 @@ public final class LifecycleToastQueue implements ToastQueue {
     showFirstToast();
   }
 
-  @Override public void enqueue(Mixture mixture, long durationMs) {
+  @Override @MainThread public void enqueue(Mixture mixture, long durationMs) {
     assertMainThread();
     boolean empty = toastDeque.isEmpty();
     toastDeque.add(new EnqueuedToast(mixture, durationMs));

--- a/frenchtoast/src/main/java/frenchtoast/Mixture.java
+++ b/frenchtoast/src/main/java/frenchtoast/Mixture.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.PixelFormat;
 import android.os.Build;
+import android.support.annotation.MainThread;
 import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
@@ -45,7 +46,7 @@ public final class Mixture {
     }
   }
 
-  public void show() {
+  @MainThread public void show() {
     assertMainThread();
     View view = toast.getView();
     if (view == null) {
@@ -82,7 +83,7 @@ public final class Mixture {
     trySendAccessibilityEvent(view);
   }
 
-  public void hide() {
+  @MainThread public void hide() {
     assertMainThread();
     View view = toast.getView();
     if (view == null) {
@@ -95,7 +96,7 @@ public final class Mixture {
     }
   }
 
-  public boolean isShowing() {
+  @MainThread public boolean isShowing() {
     assertMainThread();
     View view = toast.getView();
     return view != null && view.getParent() != null;

--- a/frenchtoast/src/main/java/frenchtoast/Toaster.java
+++ b/frenchtoast/src/main/java/frenchtoast/Toaster.java
@@ -1,6 +1,8 @@
 package frenchtoast;
 
 import android.content.res.Resources;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.StringRes;
 import android.widget.Toast;
 
 public interface Toaster {
@@ -18,7 +20,7 @@ public interface Toaster {
    * @param stringResId The resource id of the string resource to use.  Can be formatted text.
    * @throws Resources.NotFoundException if the resource can't be found.
    */
-  Toasted showText(int stringResId);
+  Toasted showText(@StringRes int stringResId);
 
   /**
    * Shows a toast that contains the inflated layout from a resource.
@@ -26,7 +28,7 @@ public interface Toaster {
    * @param layoutResId The resource id of the layout resource to use.
    * @throws Resources.NotFoundException if the resource can't be found.
    */
-  Toasted showLayout(int layoutResId);
+  Toasted showLayout(@LayoutRes int layoutResId);
 
   /**
    * Shows the provided Toast, dipped as a FrenchToast.


### PR DESCRIPTION
This is in reference to issue #4:

The latest version of the support annotations library has been added as a dependency. Methods that require invocation on the main thread are annotated with `@MainThread`. Likewise, any arguments that require a non-null value are annotated with `@NonNull`. I've also applied `@StringRes` and `@LayoutRes` to arguments that are expected to be resource IDs.
