### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your `build.gradle`:
 
 ```gradle
  dependencies {
-   compile 'info.piwai.frenchtoast:frenchtoast:1.0'
+   implementation 'info.piwai.frenchtoast:frenchtoast:1.0'
  }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.